### PR TITLE
Serialize form and not the children separately

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -115,7 +115,7 @@
         if (element.is('form')) {
           method = element.data('ujs:submit-button-formmethod') || element.attr('method');
           url = element.data('ujs:submit-button-formaction') || element.attr('action');
-          data = $(element[0].elements).serializeArray();
+          data = $(element[0]).serializeArray();
           // memoized value from clicked submit button
           var button = element.data('ujs:submit-button');
           if (button) {


### PR DESCRIPTION
If a form with data-remote=true is serialized elements inside fieldsets will be serialized twice if you call serializeArray on the forms children instead of on the form itself.

With the html

``` html
<form>
  <fieldset>
    <input type="text" name="foo" value="bar" />
  </fieldset>
</form>
```

``` javascript
$($('form')[0].elements).serializeArray();
// Outputs [ { name: 'foo', value: 'bar' }, { name: 'foo', value: 'bar' } ]
$($('form')[0]).serializeArray();
// Outputs [ { name: 'foo', value: 'bar' } ]
```
